### PR TITLE
Update solc.py

### DIFF
--- a/solcix/compile/solc.py
+++ b/solcix/compile/solc.py
@@ -479,7 +479,7 @@ def _compile_combined_json(
         solc_path = get_executable(solc_version)
 
     if output_values is None:
-        combined_json = _get_combined_json_outputs(solc_path)
+        combined_json = _get_combined_json_outputs(solc_path).strip()
     else:
         combined_json = ",".join(output_values)
 


### PR DESCRIPTION
add strip() to prevent \r in windows

## Description

Describe the issue in detail. What happened? What did you expect to happen?

## Steps to Reproduce

Please provide detailed steps for reproducing the issue, including any code snippets or examples if applicable.

1.
2.
3.

## Expected Behavior

What did you expect to happen?

## Actual Behavior

What actually happened? Please include any error messages or other relevant information.

## Environment

- Operating System:
- Python version:
- Other relevant software versions:

## Possible Solution

If you have ideas about how to solve the issue, please include them here.

## Additional Information

Add any other information that may be helpful in resolving this issue.
